### PR TITLE
Fix preloadPageCount on ViewPort

### DIFF
--- a/lib/preload_page_view.dart
+++ b/lib/preload_page_view.dart
@@ -3,7 +3,6 @@ library preload_page_view;
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -608,17 +607,9 @@ class _PreloadPageViewState extends State<PreloadPageView> {
         viewportBuilder: (BuildContext context, ViewportOffset position) {
           return Viewport(
             clipBehavior: widget.clipBehavior,
-            cacheExtent: _preloadPagesCount < 1
-                ? 0
-                : (_preloadPagesCount == 1
-                    ? 1
-                    : widget.scrollDirection == Axis.horizontal
-                        ? MediaQuery.of(context).size.width *
-                                _preloadPagesCount -
-                            1
-                        : MediaQuery.of(context).size.height *
-                                _preloadPagesCount -
-                            1),
+            cacheExtent:
+                _preloadPagesCount < 1 ? 0 : _preloadPagesCount.toDouble(),
+            cacheExtentStyle: CacheExtentStyle.viewport,
             axisDirection: axisDirection,
             offset: position,
             slivers: <Widget>[

--- a/lib/preload_page_view.dart
+++ b/lib/preload_page_view.dart
@@ -424,6 +424,7 @@ class PreloadPageView extends StatefulWidget {
     PreloadPageController? controller,
     this.physics,
     this.pageSnapping = true,
+    this.clipBehavior = Clip.hardEdge,
     this.onPageChanged,
     List<Widget> children = const <Widget>[],
     this.preloadPagesCount = 1,
@@ -452,6 +453,7 @@ class PreloadPageView extends StatefulWidget {
     PreloadPageController? controller,
     this.physics,
     this.pageSnapping = true,
+    this.clipBehavior = Clip.hardEdge,
     this.onPageChanged,
     required IndexedWidgetBuilder itemBuilder,
     int? itemCount,
@@ -470,6 +472,7 @@ class PreloadPageView extends StatefulWidget {
     PreloadPageController? controller,
     this.physics,
     this.pageSnapping = true,
+    this.clipBehavior = Clip.hardEdge,
     this.onPageChanged,
     required this.childrenDelegate,
     this.preloadPagesCount = 1,
@@ -528,6 +531,13 @@ class PreloadPageView extends StatefulWidget {
   ///
   /// [preloadPagesCount] value start from 0, default 1
   final int preloadPagesCount;
+
+  /// The content will be clipped (or not) according to this option.
+  ///
+  /// See the enum [Clip] for details of all possible options and their common use cases.
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
 
   @override
   _PreloadPageViewState createState() =>
@@ -597,6 +607,7 @@ class _PreloadPageViewState extends State<PreloadPageView> {
         physics: physics,
         viewportBuilder: (BuildContext context, ViewportOffset position) {
           return Viewport(
+            clipBehavior: widget.clipBehavior,
             cacheExtent: _preloadPagesCount < 1
                 ? 0
                 : (_preloadPagesCount == 1


### PR DESCRIPTION
The PR contains fix for the preloadPageCount param, because if it is more than 1 it works incorrectly (loads too much pages).

Not it loads the current page + preloadPageCount for both scroll directions properly.

The PR includes improvements from https://github.com/octomato/preload_page_view/pull/37.